### PR TITLE
chore: upgrade golang

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go 1.21.5
       uses: actions/setup-go@v3
       with:
-        go-version: '1.21.5'
+        go-version: '1.23.2'
 
     - name: Build
       run: make build

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module comatory/ooh-directory-bot
 
-go 1.21.5
+go 1.23.2
 
 require internal/parser v0.0.0
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 
 replace internal/client => ./internal/client
 
-require golang.org/x/net v0.19.0 // indirect
+require golang.org/x/net v0.31.0 // indirect
 
 replace internal/storage => ./internal/storage
 

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-golang.org/x/net v0.19.0 h1:zTwKpTd2XuCqf8huc7Fo2iSy+4RHPd10s4KzeTnVr1c=
-golang.org/x/net v0.19.0/go.mod h1:CfAk/cbD4CthTvqiEl8NpboMuiuOYsAr/7NOjZJtv1U=
 golang.org/x/net v0.31.0 h1:68CPQngjLL0r2AlUKiSxtQFKvzRVbnzLwMUn5SzcLHo=
 golang.org/x/net v0.31.0/go.mod h1:P4fl1q7dY2hnZFxEk4pPSkDHF+QqjitcnDjUQyMM+pM=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 golang.org/x/net v0.19.0 h1:zTwKpTd2XuCqf8huc7Fo2iSy+4RHPd10s4KzeTnVr1c=
 golang.org/x/net v0.19.0/go.mod h1:CfAk/cbD4CthTvqiEl8NpboMuiuOYsAr/7NOjZJtv1U=
+golang.org/x/net v0.31.0 h1:68CPQngjLL0r2AlUKiSxtQFKvzRVbnzLwMUn5SzcLHo=
+golang.org/x/net v0.31.0/go.mod h1:P4fl1q7dY2hnZFxEk4pPSkDHF+QqjitcnDjUQyMM+pM=


### PR DESCRIPTION
Upgrades `golang` to `1.23.2` and its dependencies